### PR TITLE
feat: add Clube Bitcoin UnB to node map

### DIFF
--- a/src/components/map/networkMap.tsx
+++ b/src/components/map/networkMap.tsx
@@ -47,7 +47,7 @@ const NetworkMap = () => {
     Japan: ["Hitotsubashi University", "Sophia University"],
     Mexico: ["Instituto Tecnológico Autónomo de México"],
     Italy: ["Politecnico di Milano", "Politecnico di Torino"],
-    Brazil: ["Clube Bitcoin São Paulo"],
+    Brazil: ["Clube Bitcoin UnB", "Clube Bitcoin São Paulo"],
     Spain: ["European Bitcoiners"],
     Australia: ["University of New South Wales"],
     Ghana: ["University of Ghana"],


### PR DESCRIPTION
Clube Bitcoin UnB is a student club from Brasília, Brazil.

https://clubebitcoinunb.com
https://x.com/ClubeBitcoinUnB
https://njump.me/npub105tr46lgr3zlz68sjyk4026y0ynd7uckzys0gk7jhpep54w4s50qzdv8xy